### PR TITLE
Add basic CSS style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ xettelkasten_server-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+/priv/notes

--- a/lib/xettelkasten_server/router.ex
+++ b/lib/xettelkasten_server/router.ex
@@ -5,6 +5,14 @@ defmodule XettelkastenServer.Router do
 
   @templates_dir "lib/xettelkasten_server/templates"
 
+  plug(
+    Plug.Static,
+    at: "/",
+    from: "lib/xettelkasten_server/templates",
+    gzip: false,
+    only: ~w(styles.css)
+  )
+
   plug(:match)
   plug(:dispatch)
 
@@ -29,12 +37,17 @@ defmodule XettelkastenServer.Router do
   end
 
   defp render(%{status: status} = conn, template, assigns) do
-    body =
-      @templates_dir
-      |> Path.join(template)
-      |> Kernel.<>(".html.eex")
-      |> EEx.eval_file(assigns)
+    inner_content = render_template(template, assigns)
+
+    body = render_template("root", inner_content: inner_content, template: template)
 
     send_resp(conn, status || 200, body)
+  end
+
+  def render_template(template, assigns) do
+    @templates_dir
+    |> Path.join(template)
+    |> Kernel.<>(".html.eex")
+    |> EEx.eval_file(assigns)
   end
 end

--- a/lib/xettelkasten_server/templates/404.html.eex
+++ b/lib/xettelkasten_server/templates/404.html.eex
@@ -1,19 +1,8 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>Xettelkasten</title>
-  </head>
-  <body>
-    <a href="/">Index</a>
-    <hr/>
-    <p>
-      Could not find a markdown file at <%= expected_path %>
-    </p>
-    <p>
-      Create a file at that location to resolve this link.
-    </p>
-  </body>
-</html>
+<p>
+  Could not find a markdown file at <%= expected_path %>
+</p>
+<p>
+  Create a file at that location to resolve this link.
+</p>
 
 

--- a/lib/xettelkasten_server/templates/note.html.eex
+++ b/lib/xettelkasten_server/templates/note.html.eex
@@ -1,13 +1,2 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>Xettelkasten</title>
-  </head>
-  <body>
-    <a href="/">Index</a>
-    <hr/>
-    <%= rendered_markdown %>
-  </body>
-</html>
+<%= rendered_markdown %>
 

--- a/lib/xettelkasten_server/templates/notes.html.eex
+++ b/lib/xettelkasten_server/templates/notes.html.eex
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>Xettelkasten</title>
-  </head>
-  <body>
-    <a href="/">Index</a>
-    <hr/>
-    <ul>
-      <%= for note <- notes do %>
-        <li>
-          <a href="/<%= note.slug %>"><%= note.title %></a>
-        </li>
-      <% end %>
-    </ul>
-  </body>
-</html>
+<ul>
+  <%= for note <- notes do %>
+    <li>
+      <a href="/<%= note.slug %>"><%= note.title %></a>
+    </li>
+  <% end %>
+</ul>

--- a/lib/xettelkasten_server/templates/root.html.eex
+++ b/lib/xettelkasten_server/templates/root.html.eex
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Xettelkasten</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <div class="nav">
+      <a href="/"><%= if template != "notes", do: "← " %>Index</a>
+    </div>
+    <hr/>
+    <div class="container">
+      <%= inner_content %>
+    </div>
+  </body>
+</html>

--- a/lib/xettelkasten_server/templates/styles.css
+++ b/lib/xettelkasten_server/templates/styles.css
@@ -1,0 +1,37 @@
+body {
+  color: #eee;
+  background-color: #334;
+}
+
+a {
+  color: #def;
+}
+
+span.backlink {
+  color: #e00;
+}
+
+span.backlink a {
+  color: #e00;
+}
+
+span.backlink a:hover {
+  color: #eaa;
+}
+
+.container {
+  margin: auto;
+  width: 67%;
+}
+
+.nav {
+  margin: auto;
+  width: 67%;
+  margin-bottom: 20px;
+}
+
+hr {
+  margin: auto;
+  width: 84%;
+  margin-bottom: 20px;
+}

--- a/test/xettelkasten_server/router_test.exs
+++ b/test/xettelkasten_server/router_test.exs
@@ -33,7 +33,7 @@ defmodule XettelkastenServer.RouterTest do
       {:ok, doc} = Floki.parse_document(conn.resp_body)
 
       index_link = Floki.find(doc, "a")
-      assert index_link == [{"a", [{"href", "/"}], ["Index"]}]
+      assert index_link == [{"a", [{"href", "/"}], ["← Index"]}]
     end
 
     test "renders the content of the linked file" do


### PR DESCRIPTION
Adds a basic dark CSS style to the views.

- Extracts root view template into its own file
- Adds Plug.Static to load the css file correctly
- More granular helper function for rendering EEx templates