### PR TITLE
Allow YAML metadata header in markdown files

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,3 @@
 import Config
+
+config :logger, :console, format: "\n[$level] $message\n"

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,3 +3,4 @@ import Config
 config :xettelkasten_server, cowboy_port: 8088
 config :xettelkasten_server, notes_directory: "test/support/notes"
 
+config :logger, level: :error

--- a/lib/xettelkasten_server/backlink.ex
+++ b/lib/xettelkasten_server/backlink.ex
@@ -1,0 +1,25 @@
+defmodule XettelkastenServer.Backlink do
+  defstruct [:text, :path, :slug, missing: false]
+
+  alias XettelkastenServer.{Note, Notes, TextHelpers}
+
+  def from_text(text) do
+    {slug, path, missing} =
+      case Notes.find_note_from_link_text(text) do
+        %Note{slug: slug, path: path} ->
+          {slug, path, false}
+
+        nil ->
+          slug = TextHelpers.text_to_slug(text)
+          path = TextHelpers.slug_to_path(slug)
+          {slug, path, true}
+      end
+
+    %__MODULE__{
+      text: text,
+      path: path,
+      slug: slug,
+      missing: missing
+    }
+  end
+end

--- a/lib/xettelkasten_server/markdown_parser.ex
+++ b/lib/xettelkasten_server/markdown_parser.ex
@@ -1,5 +1,5 @@
 defmodule XettelkastenServer.MarkdownParser do
-  alias XettelkastenServer.Note
+  alias XettelkastenServer.Backlink
 
   @backlink_regex ~r/\[\[[^]]+\]\]/
   @tag_regex ~r/\#[\S]+/
@@ -35,14 +35,14 @@ defmodule XettelkastenServer.MarkdownParser do
 
   defp parse_backlink("[[" <> str) do
     title = String.trim_trailing(str, "]")
-    note = Note.from_title(title)
+    note = Backlink.from_text(title)
 
     {
       "span",
       [{"class", "backlink"}],
       [
         "[[",
-        {"a", [{"href", "/#{note.slug}"}], [note.title], %{}},
+        {"a", [{"href", "/#{note.slug}"}], [note.text], %{}},
         "]]"
       ],
       %{}

--- a/lib/xettelkasten_server/note_file_reader.ex
+++ b/lib/xettelkasten_server/note_file_reader.ex
@@ -1,0 +1,25 @@
+defmodule XettelkastenServer.NoteFileReader do
+  @empty_yaml %{"tags" => [], "title" => nil}
+
+  def read(path) do
+    case File.read(path) do
+      {:ok, file} ->
+        {yaml, markdown} = split_yaml_and_markdown(file)
+        %{yaml: yaml, markdown: markdown}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp split_yaml_and_markdown(file) do
+    case String.split(file, "---\n", trim: true, parts: 2) do
+      [markdown] ->
+        {@empty_yaml, markdown}
+
+      [yaml, markdown] ->
+        {:ok, yaml} = YamlElixir.read_from_string(yaml)
+        {Map.merge(@empty_yaml, yaml), markdown}
+    end
+  end
+end

--- a/lib/xettelkasten_server/notes.ex
+++ b/lib/xettelkasten_server/notes.ex
@@ -1,5 +1,5 @@
 defmodule XettelkastenServer.Notes do
-  alias XettelkastenServer.Note
+  alias XettelkastenServer.{Note, TextHelpers}
 
   def all do
     XettelkastenServer.notes_directory()
@@ -9,8 +9,13 @@ defmodule XettelkastenServer.Notes do
   end
 
   def all(tag: tag) when is_bitstring(tag) do
-    {paths, 0} =
+    {paths_from_md_tag, _} =
       System.cmd("grep", ["-lr", "-e", "##{tag}\\b", XettelkastenServer.notes_directory()])
+
+    {paths_from_yaml_tag, _} =
+      System.cmd("grep", ["-lr", "-e", "- #{tag}\\b", XettelkastenServer.notes_directory()])
+
+    paths = paths_from_md_tag <> "\n" <> paths_from_yaml_tag
 
     paths
     |> String.split("\n", trim: true)
@@ -20,5 +25,12 @@ defmodule XettelkastenServer.Notes do
   def get(slug) do
     all()
     |> Enum.find(&(&1.slug == slug))
+  end
+
+  def find_note_from_link_text(text) do
+    path = TextHelpers.text_to_path(text)
+
+    all()
+    |> Enum.find(fn note -> note.path == path end)
   end
 end

--- a/lib/xettelkasten_server/templates/notes.html.eex
+++ b/lib/xettelkasten_server/templates/notes.html.eex
@@ -1,6 +1,6 @@
 <%= if tag do %>
   <h3>
-    Notes tagged with <b>#<%= tag %></b>
+    Notes tagged with <span class="tag">#<%= tag %></span>
   </h3>
 <% end %>
 <ul>

--- a/lib/xettelkasten_server/templates/root.html.eex
+++ b/lib/xettelkasten_server/templates/root.html.eex
@@ -14,21 +14,30 @@
       <h3>
         <a href="/"><%= if template != "notes", do: "← " %>Index</a>
       </h3>
-        <%= if template == "note" do %>
-          <div class="nav-tags">
-            <h5><u>Tags</u></h5>
-          </div>
+      <%= if note do %>
+        <div class="nav-tags">
+          <h5><u>Tags</u></h5>
+          <%= if length(note.tags) > 0 do %>
+            <ul>
+              <%= for tag <- note.tags do %>
+                <li class="tag">
+                  <a class="tag" href="/?tag=<%= String.trim_leading(tag, "#") %>"><%= tag %></a>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
 
-          <h4>Backlinks</h4>
+        <h4>Backlinks</h4>
 
-          <div class="nav-backlinks">
-            <h5><u>Outgoing</u></h5>
-          </div>
+        <div class="nav-backlinks">
+          <h5><u>Outgoing</u></h5>
+        </div>
 
-          <div class="nav-backlinks-incoming">
-            <h5><u>Incoming</u></h5>
-          </div>
-        <% end %>
+        <div class="nav-backlinks-incoming">
+          <h5><u>Incoming</u></h5>
+        </div>
+      <% end %>
     </nav>
     <main>
       <%= inner_content %>

--- a/lib/xettelkasten_server/text_helpers.ex
+++ b/lib/xettelkasten_server/text_helpers.ex
@@ -1,0 +1,40 @@
+defmodule XettelkastenServer.TextHelpers do
+  import XettelkastenServer, only: [notes_directory: 0]
+
+  def slug_to_path(slug) do
+    filepath =
+      slug
+      |> String.downcase()
+      |> String.replace(".", "/")
+      |> Kernel.<>(".md")
+
+    Path.join(notes_directory(), filepath)
+  end
+
+  def text_to_path(text) do
+    filepath =
+      text
+      |> convert_spaces_to_underscores()
+      |> Enum.join("/")
+      |> Kernel.<>(".md")
+
+    Path.join(notes_directory(), filepath)
+  end
+
+  def text_to_slug(text) do
+    text
+    |> convert_spaces_to_underscores()
+    |> Enum.join(".")
+  end
+
+  defp convert_spaces_to_underscores(text) do
+    text
+    |> String.downcase()
+    |> String.split("/")
+    |> Enum.map(fn nest ->
+      nest
+      |> String.trim(" ")
+      |> String.replace(" ", "_")
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule XettelkastenServer.MixProject do
       {:earmark, "~> 1.4.24"},
       {:floki, "~> 0.32.0", only: [:dev, :test]},
       {:plug_cowboy, "~> 2.0"},
-      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false}
+      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:yaml_elixir, "~> 2.8"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -14,4 +14,6 @@
   "plug_crypto": {:hex, :plug_crypto, "1.2.2", "05654514ac717ff3a1843204b424477d9e60c143406aa94daf2274fdd280794d", [:mix], [], "hexpm", "87631c7ad914a5a445f0a3809f99b079113ae4ed4b867348dd9eec288cecb6db"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
+  "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.8.0", "c7ff0034daf57279c2ce902788ce6fdb2445532eb4317e8df4b044209fae6832", [:mix], [{:yamerl, "~> 0.8", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "4b674bd881e373d1ac6a790c64b2ecb69d1fd612c2af3b22de1619c15473830b"},
 }

--- a/priv/static/styles.css
+++ b/priv/static/styles.css
@@ -45,6 +45,10 @@ a:hover {
   color: var(--link-hover-color);
 }
 
+.tag {
+  color: var(--tag-link-color);
+}
+
 a.tag {
   color: var(--tag-link-color);
   text-decoration: none;

--- a/test/support/notes/nested/bird.md
+++ b/test/support/notes/nested/bird.md
@@ -1,3 +1,4 @@
+---
 # I'm a bird
 
 Just a pretty little tweety bird

--- a/test/support/notes/with_header.md
+++ b/test/support/notes/with_header.md
@@ -1,0 +1,10 @@
+title: My Cool Note
+tags:
+- awesome
+- sweet
+- prettycool
+---
+
+This is just the rest of the post with a [[backlink]]
+
+and some #tags #more_tags #awesome

--- a/test/support/notes/with_header_and_h1.md
+++ b/test/support/notes/with_header_and_h1.md
@@ -1,0 +1,3 @@
+title: Hello
+---
+# Foo bar

--- a/test/xettelkasten_server/backlink_test.exs
+++ b/test/xettelkasten_server/backlink_test.exs
@@ -1,0 +1,34 @@
+defmodule XettelkastenServer.BacklinkTest do
+  use ExUnit.Case, async: true
+
+  alias XettelkastenServer.Backlink
+
+  describe "from_text" do
+    test "works with a simple case matching filename" do
+      backlink = Backlink.from_text("Simple")
+
+      assert backlink.text == "Simple"
+      assert backlink.path == Path.join(XettelkastenServer.notes_directory(), "simple.md")
+      assert backlink.slug == "simple"
+      refute backlink.missing
+    end
+
+    test "works with a nested filename" do
+      backlink = Backlink.from_text("Nested / Bird")
+
+      assert backlink.text == "Nested / Bird"
+      assert backlink.path == Path.join(XettelkastenServer.notes_directory(), "nested/bird.md")
+      assert backlink.slug == "nested.bird"
+      refute backlink.missing
+    end
+
+    test "works with a missing filename" do
+      backlink = Backlink.from_text("Not A Note")
+
+      assert backlink.text == "Not A Note"
+      assert backlink.path == Path.join(XettelkastenServer.notes_directory(), "not_a_note.md")
+      assert backlink.slug == "not_a_note"
+      assert backlink.missing
+    end
+  end
+end

--- a/test/xettelkasten_server/note_file_reader_test.exs
+++ b/test/xettelkasten_server/note_file_reader_test.exs
@@ -1,0 +1,46 @@
+defmodule XettelkastenServer.NoteFileReaderTest do
+  use ExUnit.Case, async: true
+
+  alias XettelkastenServer.NoteFileReader
+
+  test "parses the file into yaml header and markdown body" do
+    path = note_path("with_header")
+
+    file_contents = NoteFileReader.read(path)
+
+    assert file_contents.yaml == %{
+             "title" => "My Cool Note",
+             "tags" => ~w(awesome sweet prettycool)
+           }
+
+    assert is_bitstring(file_contents.markdown)
+  end
+
+  test "returns an empty yaml header when it is not present" do
+    path = note_path("simple")
+
+    file_contents = NoteFileReader.read(path)
+
+    assert file_contents.yaml == %{"tags" => [], "title" => nil}
+    assert is_bitstring(file_contents.markdown)
+  end
+
+  test "returns an empty yaml header when the divider is present but no yaml is included" do
+    path = note_path("nested/bird")
+
+    file_contents = NoteFileReader.read(path)
+
+    assert file_contents.yaml == %{"tags" => [], "title" => nil}
+    assert is_bitstring(file_contents.markdown)
+  end
+
+  test "returns posix error if file cannot be read" do
+    path = note_path("not_a_note")
+
+    assert NoteFileReader.read(path) == {:error, :enoent}
+  end
+
+  def note_path(filename) do
+    Path.join(XettelkastenServer.notes_directory(), filename <> ".md")
+  end
+end

--- a/test/xettelkasten_server/note_test.exs
+++ b/test/xettelkasten_server/note_test.exs
@@ -10,65 +10,51 @@ defmodule XettelkastenServer.NoteTest do
       assert Note.from_path(path) == %Note{
                path: path,
                slug: "simple",
-               title: "Simple"
+               title: "Simple",
+               markdown: "# A simple note\n\nHello there!\n"
              }
     end
 
-    test "nested" do
+    test "when the file doesn't exist" do
       path = note_path("nested/simple.md")
+
+      assert Note.from_path(path) == nil
+    end
+
+    test "with header metadata" do
+      path = note_path("with_header.md")
 
       assert Note.from_path(path) == %Note{
                path: path,
-               slug: "nested.simple",
-               title: "Nested/Simple"
+               slug: "with_header",
+               title: "My Cool Note",
+               tags: ~w(#awesome #more_tags #prettycool #sweet #tags),
+               markdown:
+                 "\nThis is just the rest of the post with a [[backlink]]\n\nand some #tags #more_tags #awesome\n"
+             }
+    end
+
+    test "with header metadata and an h1 tag" do
+      path = note_path("with_header_and_h1.md")
+
+      assert Note.from_path(path) == %Note{
+               path: path,
+               slug: "with_header_and_h1",
+               title: "Hello",
+               tags: [],
+               markdown: "# Foo bar\n"
              }
     end
   end
 
-  describe "from slug" do
-    test "unnested" do
-      assert Note.from_slug("basic_note") == %Note{
-               path: note_path("basic_note.md"),
-               slug: "basic_note",
-               title: "Basic Note"
-             }
-    end
-
-    test "nested" do
-      assert Note.from_slug("deeply.nested.basic_note") == %Note{
-               path: note_path("deeply/nested/basic_note.md"),
-               slug: "deeply.nested.basic_note",
-               title: "Deeply/Nested/Basic Note"
-             }
-    end
-  end
-
-  describe "from title" do
-    test "unnested" do
-      assert Note.from_title("GREAT Note") == %Note{
-               path: note_path("great_note.md"),
-               slug: "great_note",
-               title: "GREAT Note"
-             }
-    end
-
-    test "nested" do
-      assert Note.from_title("GREAT/Note") == %Note{
-               path: note_path("great/note.md"),
-               slug: "great.note",
-               title: "GREAT/Note"
-             }
-    end
-  end
-
-  describe "read" do
+  describe "parse_markdown" do
     test "returns Earmark tuple for an existing note" do
       note =
         "simple.md"
         |> note_path()
         |> Note.from_path()
 
-      html = Note.read(note)
+      html = Note.parse_markdown(note)
 
       {:ok, doc} = Floki.parse_document(html)
 
@@ -82,7 +68,7 @@ defmodule XettelkastenServer.NoteTest do
         |> note_path()
         |> Note.from_path()
 
-      html = Note.read(note)
+      html = Note.parse_markdown(note)
 
       {:ok, doc} = Floki.parse_document(html)
 
@@ -101,7 +87,7 @@ defmodule XettelkastenServer.NoteTest do
         |> note_path()
         |> Note.from_path()
 
-      html = Note.read(note)
+      html = Note.parse_markdown(note)
 
       {:ok, doc} = Floki.parse_document(html)
 
@@ -121,7 +107,7 @@ defmodule XettelkastenServer.NoteTest do
         |> note_path()
         |> Note.from_path()
 
-      assert Note.read(note) == {:error, :enoent}
+      assert Note.parse_markdown(note) == {:error, :enoent}
     end
   end
 

--- a/test/xettelkasten_server/notes_test.exs
+++ b/test/xettelkasten_server/notes_test.exs
@@ -7,17 +7,19 @@ defmodule XettelkastenServer.NotesTest do
   describe "all" do
     test "untagged" do
       assert Notes.all() == [
-               Note.from_slug("backlinks"),
-               Note.from_slug("nested.bird"),
-               Note.from_slug("simple"),
-               Note.from_slug("simple_backlink"),
-               Note.from_slug("tag")
+               note_from_filepath("backlinks"),
+               note_from_filepath("nested/bird"),
+               note_from_filepath("simple"),
+               note_from_filepath("simple_backlink"),
+               note_from_filepath("tag"),
+               note_from_filepath("with_header"),
+               note_from_filepath("with_header_and_h1")
              ]
     end
 
     test "tagged" do
       assert Notes.all(tag: "tag") == [
-               Note.from_slug("tag")
+               note_from_filepath("tag")
              ]
     end
   end
@@ -27,12 +29,19 @@ defmodule XettelkastenServer.NotesTest do
       assert Notes.get("simple") == %Note{
                path: "test/support/notes/simple.md",
                slug: "simple",
-               title: "Simple"
+               title: "Simple",
+               markdown: "# A simple note\n\nHello there!\n"
              }
     end
 
     test "when the note doesn't exist" do
       refute Notes.get("not_a_note")
     end
+  end
+
+  def note_from_filepath(filepath) do
+    path = Path.join(XettelkastenServer.notes_directory(), filepath <> ".md")
+
+    Note.from_path(path)
   end
 end

--- a/test/xettelkasten_server/text_helpers_test.exs
+++ b/test/xettelkasten_server/text_helpers_test.exs
@@ -1,0 +1,43 @@
+defmodule XettelkastenServer.TextHelpersTest do
+  use ExUnit.Case, async: true
+
+  import XettelkastenServer, only: [notes_directory: 0]
+
+  alias XettelkastenServer.TextHelpers
+
+  describe "slug_to_path" do
+    test "with a simple slug" do
+      assert TextHelpers.slug_to_path("basic") ==
+               Path.join(
+                 notes_directory(),
+                 "basic.md"
+               )
+    end
+
+    test "with a nested_slug" do
+      assert TextHelpers.slug_to_path("nested.bird") ==
+               Path.join(
+                 notes_directory(),
+                 "nested/bird.md"
+               )
+    end
+  end
+
+  describe "text_to_path" do
+    test "works with any text" do
+      assert TextHelpers.text_to_path("A Simple Path") ==
+               Path.join(
+                 notes_directory(),
+                 "a_simple_path.md"
+               )
+    end
+
+    test "counts forward slashes as nesting" do
+      assert TextHelpers.text_to_path("A / Simple /Path") ==
+               Path.join(
+                 notes_directory(),
+                 "a/simple/path.md"
+               )
+    end
+  end
+end

--- a/test/xettelkasten_server_test.exs
+++ b/test/xettelkasten_server_test.exs
@@ -1,3 +1,0 @@
-defmodule XettelkastenServerTest do
-  use ExUnit.Case
-end


### PR DESCRIPTION
Allow parsing YAML metadata from a header section in markdown files

Update `Note` struct to hold raw markdown and tags and title parsed from the header, or falling back to a title built from the filepath.

Add `Backlink` to construct backlinks which store the text of the link, the expected path and slug based on that title, and whether or not the expected file exists.

On the note page view, display all tags as links in the left nav, concatenating tags from the header with tags in the markdown body


- Add `Plug.Logger` to `XettelkastenServer.Router`
- Add helper methods to `XettelkastenServer.TextHelpers` for common conversions between slugs, text, and paths
