### PR TITLE
Allow injection of h1 tag to notes with metadata title or filepath

### DIFF
--- a/lib/xettelkasten_server/markdown_parser.ex
+++ b/lib/xettelkasten_server/markdown_parser.ex
@@ -4,7 +4,7 @@ defmodule XettelkastenServer.MarkdownParser do
   @backlink_regex ~r/\[\[[^]]+\]\]/
   @tag_regex ~r/\#[\S]+/
 
-  def parse(markdown) when is_bitstring(markdown) do
+  def parse(markdown, title \\ nil) when is_bitstring(markdown) do
     {:ok, ast, _} = Earmark.as_ast(markdown)
 
     ast =
@@ -13,6 +13,13 @@ defmodule XettelkastenServer.MarkdownParser do
         |> detect_backlinks()
         |> detect_tags()
       end)
+
+    ast =
+      if title do
+        set_h1(ast, title)
+      else
+        ast
+      end
 
     {:ok, ast}
   end
@@ -72,4 +79,15 @@ defmodule XettelkastenServer.MarkdownParser do
   end
 
   defp parse_tag(str), do: str
+
+  defp set_h1(ast, title) do
+    case ast do
+      [{"h1", _, _, _} | _] ->
+        ast
+
+      _ ->
+        h1 = {"h1", [], [[title]], %{}}
+        [h1, ast]
+    end
+  end
 end

--- a/lib/xettelkasten_server/note.ex
+++ b/lib/xettelkasten_server/note.ex
@@ -39,8 +39,8 @@ defmodule XettelkastenServer.Note do
     }
   end
 
-  def parse_markdown(%__MODULE__{markdown: markdown}) do
-    with {:ok, ast} <- XettelkastenServer.MarkdownParser.parse(markdown) do
+  def parse_markdown(%__MODULE__{markdown: markdown, title: title}) do
+    with {:ok, ast} <- XettelkastenServer.MarkdownParser.parse(markdown, title) do
       Earmark.Transform.transform(ast)
     end
   end

--- a/lib/xettelkasten_server/text_helpers.ex
+++ b/lib/xettelkasten_server/text_helpers.ex
@@ -27,6 +27,19 @@ defmodule XettelkastenServer.TextHelpers do
     |> Enum.join(".")
   end
 
+  def path_to_text(path) do
+    path
+    |> Path.rootname()
+    |> String.split("/")
+    |> Enum.map(fn nest ->
+      nest
+      |> String.split("_")
+      |> Enum.map(&String.capitalize/1)
+      |> Enum.join(" ")
+    end)
+    |> Enum.join(" / ")
+  end
+
   defp convert_spaces_to_underscores(text) do
     text
     |> String.downcase()

--- a/test/support/notes/with_neither_header_nor_h1.md
+++ b/test/support/notes/with_neither_header_nor_h1.md
@@ -1,0 +1,6 @@
+---
+tags:
+- foo
+---
+
+Hello

--- a/test/xettelkasten_server/markdown_parser_test.exs
+++ b/test/xettelkasten_server/markdown_parser_test.exs
@@ -1,7 +1,7 @@
 defmodule XettelkastenServer.MarkdownParserTest do
   use ExUnit.Case, async: true
 
-  alias XettelkastenServer.MarkdownParser
+  alias XettelkastenServer.{MarkdownParser, Note}
 
   describe "backlinks" do
     test "parse correctly handles a simple backlink" do
@@ -114,5 +114,30 @@ defmodule XettelkastenServer.MarkdownParserTest do
                   ], %{}}
                ]
     end
+  end
+
+  describe "maybe_add_header_from_metadata" do
+    test "leaves an existing h1 tag unchanged" do
+      note = Note.from_path(note_path("with_header_and_h1"))
+
+      {:ok, ast} = MarkdownParser.parse(note.markdown, "Hello")
+
+      assert {"h1", [], [["Foo bar"]], %{}} in ast
+    end
+
+    test "inserts a header from metadata if no h1 tag is present" do
+      note = Note.from_path(note_path("with_header"))
+
+      {:ok, ast} = MarkdownParser.parse(note.markdown, "My Cool Note")
+
+      assert {"h1", [], [["My Cool Note"]], %{}} in ast
+    end
+  end
+
+  defp note_path(filename) do
+    Path.join(
+      XettelkastenServer.notes_directory(),
+      filename <> ".md"
+    )
   end
 end

--- a/test/xettelkasten_server/notes_test.exs
+++ b/test/xettelkasten_server/notes_test.exs
@@ -13,7 +13,8 @@ defmodule XettelkastenServer.NotesTest do
                note_from_filepath("simple_backlink"),
                note_from_filepath("tag"),
                note_from_filepath("with_header"),
-               note_from_filepath("with_header_and_h1")
+               note_from_filepath("with_header_and_h1"),
+               note_from_filepath("with_neither_header_nor_h1")
              ]
     end
 

--- a/test/xettelkasten_server/router_test.exs
+++ b/test/xettelkasten_server/router_test.exs
@@ -149,6 +149,51 @@ defmodule XettelkastenServer.RouterTest do
     end
   end
 
+  test "renders the correct initial h1 with h1 and metadata" do
+    conn =
+      :get
+      |> conn("/with_header_and_h1", "")
+      |> Router.call(@opts)
+
+    assert conn.status == 200
+
+    {:ok, doc} = Floki.parse_document(conn.resp_body)
+
+    [{"h1", _, [header]}] = Floki.find(doc, "h1")
+
+    assert String.trim(header) == "Foo bar"
+  end
+
+  test "renders the correct initial h1 with just metadata" do
+    conn =
+      :get
+      |> conn("/with_header", "")
+      |> Router.call(@opts)
+
+    assert conn.status == 200
+
+    {:ok, doc} = Floki.parse_document(conn.resp_body)
+
+    [{"h1", _, [header]}] = Floki.find(doc, "h1")
+
+    assert String.trim(header) == "My Cool Note"
+  end
+
+  test "renders the correct initial h1 with neither h1 nor metadata" do
+    conn =
+      :get
+      |> conn("/with_neither_header_nor_h1", "")
+      |> Router.call(@opts)
+
+    assert conn.status == 200
+
+    {:ok, doc} = Floki.parse_document(conn.resp_body)
+
+    [{"h1", _, [header]}] = Floki.find(doc, "h1")
+
+    assert String.trim(header) == "With Neither Header Nor H1"
+  end
+
   describe "/:slug with an invalid slug" do
     test "renders a 404 page if the unnested slug doesn't map to a existing file" do
       conn =


### PR DESCRIPTION
When parsing a note's markdown, pass its title metadata to be injected into the markdown AST in the event that it does not have an initial h1 tag. this metadata is either the title from the markdown's yaml frontmatter, or a constructed title from the note's filepath