### PR TITLE
Updates to backlink and header behaviour

### DIFF
--- a/lib/xettelkasten_server/notes.ex
+++ b/lib/xettelkasten_server/notes.ex
@@ -29,8 +29,9 @@ defmodule XettelkastenServer.Notes do
 
   def find_note_from_link_text(text) do
     path = TextHelpers.text_to_path(text)
+    possible_title = String.downcase(text)
 
     all()
-    |> Enum.find(fn note -> note.path == path end)
+    |> Enum.find(fn note -> note.path == path || String.downcase(note.title) == possible_title end)
   end
 end

--- a/priv/static/styles.css
+++ b/priv/static/styles.css
@@ -62,6 +62,10 @@ span.backlink {
   color: var(--backlink-link-color);
 }
 
+span.backlink.missing {
+  text-decoration: line-through;
+}
+
 span.backlink a {
   color: var(--backlink-link-color);
   text-decoration: none;

--- a/test/support/notes/nested/no_title.md
+++ b/test/support/notes/nested/no_title.md
@@ -1,0 +1,5 @@
+hello
+
+[[Nested / Bird]]
+
+[[I'm a bird]]

--- a/test/xettelkasten_server/backlink_test.exs
+++ b/test/xettelkasten_server/backlink_test.exs
@@ -30,5 +30,14 @@ defmodule XettelkastenServer.BacklinkTest do
       assert backlink.slug == "not_a_note"
       assert backlink.missing
     end
+
+    test "works with a note's title" do
+      backlink = Backlink.from_text("I'm a bird")
+
+      assert backlink.text == "I'm a bird"
+      assert backlink.path == Path.join(XettelkastenServer.notes_directory(), "nested/bird.md")
+      assert backlink.slug == "nested.bird"
+      refute backlink.missing
+    end
   end
 end

--- a/test/xettelkasten_server/note_test.exs
+++ b/test/xettelkasten_server/note_test.exs
@@ -10,7 +10,7 @@ defmodule XettelkastenServer.NoteTest do
       assert Note.from_path(path) == %Note{
                path: path,
                slug: "simple",
-               title: "Simple",
+               title: "A simple note",
                markdown: "# A simple note\n\nHello there!\n"
              }
     end
@@ -99,6 +99,34 @@ defmodule XettelkastenServer.NoteTest do
       assert String.trim(text) == "#tag"
       assert {"href", "/?tag=tag"} in attrs
       assert {"class", "tag"} in attrs
+    end
+
+    test "inserts a title from the metadata header if an h1 tag is not present" do
+      note =
+        "with_header.md"
+        |> note_path()
+        |> Note.from_path()
+
+      html = Note.parse_markdown(note)
+
+      {:ok, doc} = Floki.parse_document(html)
+
+      [{"h1", _, [header]}] = Floki.find(doc, "h1")
+      assert String.trim(header) == "My Cool Note"
+    end
+
+    test "inserts a titleized version of the note path when no h1 tag or header title is present" do
+      note =
+        "nested/no_title.md"
+        |> note_path()
+        |> Note.from_path()
+
+      html = Note.parse_markdown(note)
+
+      {:ok, doc} = Floki.parse_document(html)
+
+      [{"h1", _, [header]}] = Floki.find(doc, "h1")
+      assert String.trim(header) == "Nested / No Title"
     end
 
     test "returns posix error for a missing note" do

--- a/test/xettelkasten_server/notes_test.exs
+++ b/test/xettelkasten_server/notes_test.exs
@@ -9,6 +9,7 @@ defmodule XettelkastenServer.NotesTest do
       assert Notes.all() == [
                note_from_filepath("backlinks"),
                note_from_filepath("nested/bird"),
+               note_from_filepath("nested/no_title"),
                note_from_filepath("simple"),
                note_from_filepath("simple_backlink"),
                note_from_filepath("tag"),
@@ -30,13 +31,27 @@ defmodule XettelkastenServer.NotesTest do
       assert Notes.get("simple") == %Note{
                path: "test/support/notes/simple.md",
                slug: "simple",
-               title: "Simple",
+               title: "A simple note",
                markdown: "# A simple note\n\nHello there!\n"
              }
     end
 
     test "when the note doesn't exist" do
       refute Notes.get("not_a_note")
+    end
+  end
+
+  describe "find_note_from_link_text" do
+    test "when the text parses into a note path" do
+      assert Notes.find_note_from_link_text("Nested / Bird") == Notes.get("nested.bird")
+    end
+
+    test "when the text parses to a note's title" do
+      assert Notes.find_note_from_link_text("I'm a bird") == Notes.get("nested.bird")
+    end
+
+    test "when no note can be found" do
+      refute Notes.find_note_from_link_text("No chance in hell")
     end
   end
 

--- a/test/xettelkasten_server/router_test.exs
+++ b/test/xettelkasten_server/router_test.exs
@@ -18,7 +18,7 @@ defmodule XettelkastenServer.RouterTest do
     links = Floki.find(doc, "a")
 
     assert {"a", [{"href", "/"}], ["Index"]} in links
-    assert {"a", [{"href", "/simple"}], ["Simple"]} in links
+    assert {"a", [{"href", "/simple"}], ["A simple note"]} in links
     assert {"a", [{"href", "/backlinks"}], ["Backlinks"]} in links
   end
 


### PR DESCRIPTION
Update behaviour around headers and backlinks

# Headers

Ensure an `<h1>` header is always present as the first element of a note.

Its content is specified by, in order:

1. an `<h1>` tag present as the first element of a note
2. a title provided in the note's yaml metadata
3. a titleized form of the note's file path

# Backlinks

Backlinks whose content is a note's header (see above) will correctly link to the note

Backlinks can also still be defined using the note's filepath

Backlinks that do not resolve to an existing note are displayed with a strikethrough
