### PR TITLE
Provide bidirectional backlink catalogs when viewing a note

### DIFF
--- a/lib/xettelkasten_server/backlink.ex
+++ b/lib/xettelkasten_server/backlink.ex
@@ -1,25 +1,16 @@
 defmodule XettelkastenServer.Backlink do
   defstruct [:text, :path, :slug, missing: false]
 
-  alias XettelkastenServer.{Note, Notes, TextHelpers}
+  alias XettelkastenServer.{TextHelpers}
 
   def from_text(text) do
-    {slug, path, missing} =
-      case Notes.find_note_from_link_text(text) do
-        %Note{slug: slug, path: path} ->
-          {slug, path, false}
-
-        nil ->
-          slug = TextHelpers.text_to_slug(text)
-          path = TextHelpers.slug_to_path(slug)
-          {slug, path, true}
-      end
+    path = TextHelpers.text_to_path(text)
 
     %__MODULE__{
       text: text,
       path: path,
-      slug: slug,
-      missing: missing
+      slug: TextHelpers.text_to_slug(text),
+      missing: !File.exists?(path)
     }
   end
 end

--- a/lib/xettelkasten_server/markdown_parser.ex
+++ b/lib/xettelkasten_server/markdown_parser.ex
@@ -7,19 +7,25 @@ defmodule XettelkastenServer.MarkdownParser do
   def parse(markdown, title \\ nil) when is_bitstring(markdown) do
     {:ok, ast, _} = Earmark.as_ast(markdown)
 
+    {:ok, backlink_agent} = Agent.start_link(fn -> [] end)
+
     ast =
       Earmark.Transform.map_ast(ast, fn node ->
         node
-        |> detect_backlinks()
+        |> detect_backlinks(backlink_agent)
         |> detect_tags()
       end)
       |> ensure_h1_tag(title)
 
-    {:ok, ast}
+    backlinks = Agent.get(backlink_agent, & &1) |> Enum.reverse()
+
+    Agent.stop(backlink_agent)
+
+    {:ok, ast, backlinks}
   end
 
-  defp detect_backlinks(node) when is_bitstring(node) do
-    res = parse_backlinks(node)
+  defp detect_backlinks(node, agent) when is_bitstring(node) do
+    res = parse_backlinks(node, agent)
 
     case length(res) do
       1 -> List.first(res)
@@ -27,16 +33,18 @@ defmodule XettelkastenServer.MarkdownParser do
     end
   end
 
-  defp detect_backlinks(node), do: node
+  defp detect_backlinks(node, _), do: node
 
-  defp parse_backlinks(str) do
+  defp parse_backlinks(str, agent) do
     Regex.split(@backlink_regex, str, include_captures: true, trim: true)
-    |> Enum.map(&parse_backlink/1)
+    |> Enum.map(&parse_backlink(&1, agent))
   end
 
-  defp parse_backlink("[[" <> str) do
+  defp parse_backlink("[[" <> str, agent) do
     title = String.trim_trailing(str, "]")
     backlink = Backlink.from_text(title)
+
+    Agent.update(agent, &[backlink | &1])
 
     classes =
       ["backlink", if(backlink.missing, do: "missing")]
@@ -55,7 +63,7 @@ defmodule XettelkastenServer.MarkdownParser do
     }
   end
 
-  defp parse_backlink(str), do: str
+  defp parse_backlink(str, _), do: str
 
   defp detect_tags(node) when is_bitstring(node) do
     parse_tags(node)

--- a/lib/xettelkasten_server/notes.ex
+++ b/lib/xettelkasten_server/notes.ex
@@ -1,5 +1,5 @@
 defmodule XettelkastenServer.Notes do
-  alias XettelkastenServer.{Note, TextHelpers}
+  alias XettelkastenServer.Note
 
   def all do
     XettelkastenServer.notes_directory()
@@ -27,11 +27,10 @@ defmodule XettelkastenServer.Notes do
     |> Enum.find(&(&1.slug == slug))
   end
 
-  def find_note_from_link_text(text) do
-    path = TextHelpers.text_to_path(text)
-    possible_title = String.downcase(text)
-
+  def with_backlinks_to(slug) do
     all()
-    |> Enum.find(fn note -> note.path == path || String.downcase(note.title) == possible_title end)
+    |> Enum.filter(fn %{backlinks: backlinks} ->
+      slug in Enum.map(backlinks, & &1.slug)
+    end)
   end
 end

--- a/lib/xettelkasten_server/text_helpers.ex
+++ b/lib/xettelkasten_server/text_helpers.ex
@@ -1,6 +1,18 @@
 defmodule XettelkastenServer.TextHelpers do
   import XettelkastenServer, only: [notes_directory: 0]
 
+  def titleize(s) do
+    s
+    |> String.split("/", trim: true)
+    |> Enum.map(fn nest ->
+      nest
+      |> String.split(" ", trim: true)
+      |> Enum.map(&String.capitalize/1)
+      |> Enum.join(" ")
+    end)
+    |> Enum.join(" / ")
+  end
+
   def slug_to_path(slug) do
     filepath =
       slug

--- a/priv/static/styles.css
+++ b/priv/static/styles.css
@@ -38,6 +38,7 @@ nav .nav-list ul {
   list-style: none;
   padding-left: 8px;
   margin-top: 8px;
+  line-height: 1.3em;
 }
 
 nav .nav-list h4 {
@@ -62,6 +63,10 @@ a:hover {
   color: var(--tag-link-color);
 }
 
+.backlink {
+  color: var(--backlink-link-color);
+}
+
 a.tag {
   color: var(--tag-link-color);
   text-decoration: none;
@@ -75,16 +80,16 @@ span.backlink {
   color: var(--backlink-link-color);
 }
 
-span.backlink.missing {
+.backlink.missing {
   text-decoration: line-through;
 }
 
-span.backlink a {
+.backlink a {
   color: var(--backlink-link-color);
   text-decoration: none;
 }
 
-span.backlink a:hover {
+.backlink a:hover {
   color: var(--backlink-hover-color);
 }
 

--- a/priv/static/templates/root.html.eex
+++ b/priv/static/templates/root.html.eex
@@ -27,6 +27,32 @@
               </ul>
           </div>
         <% end %>
+
+        <%= if length(note.backlinks) > 0 do %>
+          <div class="nav-list outgoing-backlinks">
+            <h4>Notes linked from this note</h4>
+            <ul>
+              <%= for backlink <- note.backlinks do %>
+                <li class="backlink <%= if backlink.missing, do: "missing" %>">
+                  [[<a class="backlink" href="/<%= backlink.slug %>"><%= XettelkastenServer.TextHelpers.titleize(backlink.text) %></a>]]
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <%= if length(incoming_backlinks) > 0 do %>
+          <div class="nav-list incoming-backlinks">
+            <h4>Notes linking to this note</h4>
+            <ul>
+              <%= for backlink <- incoming_backlinks do %>
+                <li class="backlink <%= if backlink.missing, do: "missing" %>">
+                  [[<a class="backlink" href="/<%= backlink.slug %>"><%= XettelkastenServer.TextHelpers.titleize(backlink.text) %></a>]]
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
       <% end %>
     </nav>
     <main>

--- a/test/support/notes/with_neither_header_nor_h1.md
+++ b/test/support/notes/with_neither_header_nor_h1.md
@@ -4,3 +4,5 @@ tags:
 ---
 
 Hello
+
+[[backlinks]]

--- a/test/xettelkasten_server/backlink_test.exs
+++ b/test/xettelkasten_server/backlink_test.exs
@@ -30,14 +30,5 @@ defmodule XettelkastenServer.BacklinkTest do
       assert backlink.slug == "not_a_note"
       assert backlink.missing
     end
-
-    test "works with a note's title" do
-      backlink = Backlink.from_text("I'm a bird")
-
-      assert backlink.text == "I'm a bird"
-      assert backlink.path == Path.join(XettelkastenServer.notes_directory(), "nested/bird.md")
-      assert backlink.slug == "nested.bird"
-      refute backlink.missing
-    end
   end
 end

--- a/test/xettelkasten_server/markdown_parser_test.exs
+++ b/test/xettelkasten_server/markdown_parser_test.exs
@@ -5,7 +5,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
 
   describe "backlinks" do
     test "parse correctly handles a simple backlink" do
-      {:ok, ast} = MarkdownParser.parse("[[simple]]")
+      {:ok, ast, _} = MarkdownParser.parse("[[simple]]")
 
       assert ast ==
                [
@@ -22,7 +22,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
     end
 
     test "parse correctly handles a nested backlink" do
-      {:ok, ast} = MarkdownParser.parse("- [[simple]]")
+      {:ok, ast, _} = MarkdownParser.parse("- [[simple]]")
 
       assert ast ==
                [
@@ -42,7 +42,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
     end
 
     test "parse correctly handles a backlink with a missing file" do
-      {:ok, ast} = MarkdownParser.parse("[[no good]]")
+      {:ok, ast, _} = MarkdownParser.parse("[[no good]]")
 
       assert ast ==
                [
@@ -59,7 +59,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
     end
 
     test "parse correctly handles multiple backlinks in one line" do
-      {:ok, ast} = MarkdownParser.parse("this is one [[backlinks]] and [[Another]]")
+      {:ok, ast, _} = MarkdownParser.parse("this is one [[backlinks]] and [[Another]]")
 
       assert ast ==
                [
@@ -84,30 +84,11 @@ defmodule XettelkastenServer.MarkdownParserTest do
                   ], %{}}
                ]
     end
-
-    test "correctly parse backlinks from path and title to the same note" do
-      {:ok, ast} = MarkdownParser.parse("[[Nested / Bird]] [[I'm a bird]]")
-
-      assert ast ==
-               [
-                 {"p", [],
-                  [
-                    [
-                      {"span", [{"class", "backlink"}],
-                       ["[[", {"a", [{"href", "/nested.bird"}], ["Nested / Bird"], %{}}, "]]"],
-                       %{}},
-                      " ",
-                      {"span", [{"class", "backlink"}],
-                       ["[[", {"a", [{"href", "/nested.bird"}], ["I'm a bird"], %{}}, "]]"], %{}}
-                    ]
-                  ], %{}}
-               ]
-    end
   end
 
   describe "tags" do
     test "single tag" do
-      {:ok, ast} = MarkdownParser.parse("#tag")
+      {:ok, ast, _} = MarkdownParser.parse("#tag")
 
       assert ast ==
                [
@@ -119,7 +100,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
     end
 
     test "multiple tags" do
-      {:ok, ast} = MarkdownParser.parse("#tag #second_tag")
+      {:ok, ast, _} = MarkdownParser.parse("#tag #second_tag")
 
       assert ast ==
                [
@@ -136,7 +117,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
     end
 
     test "non-initial tag" do
-      {:ok, ast} = MarkdownParser.parse("this tag is a #tag tag")
+      {:ok, ast, _} = MarkdownParser.parse("this tag is a #tag tag")
 
       assert ast ==
                [
@@ -154,7 +135,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
 
   describe "ensure_h1_tag" do
     test "leaves an existing h1 tag unchanged" do
-      {:ok, ast} = MarkdownParser.parse("# Hello", "Better title")
+      {:ok, ast, _} = MarkdownParser.parse("# Hello", "Better title")
 
       assert ast == [
                {"h1", [], [["Hello"]], %{}}
@@ -162,7 +143,7 @@ defmodule XettelkastenServer.MarkdownParserTest do
     end
 
     test "inserts a header from metadata if no h1 tag is present" do
-      {:ok, ast} = MarkdownParser.parse("hello", "Better title")
+      {:ok, ast, _} = MarkdownParser.parse("hello", "Better title")
 
       assert ast == [
                {"h1", [], [["Better title"]], %{}},

--- a/test/xettelkasten_server/notes_test.exs
+++ b/test/xettelkasten_server/notes_test.exs
@@ -28,12 +28,11 @@ defmodule XettelkastenServer.NotesTest do
 
   describe "get" do
     test "when the note exists" do
-      assert Notes.get("simple") == %Note{
+      assert %Note{
                path: "test/support/notes/simple.md",
                slug: "simple",
-               title: "A simple note",
-               markdown: "# A simple note\n\nHello there!\n"
-             }
+               title: "A simple note"
+             } = Notes.get("simple")
     end
 
     test "when the note doesn't exist" do
@@ -41,17 +40,11 @@ defmodule XettelkastenServer.NotesTest do
     end
   end
 
-  describe "find_note_from_link_text" do
-    test "when the text parses into a note path" do
-      assert Notes.find_note_from_link_text("Nested / Bird") == Notes.get("nested.bird")
-    end
+  describe "with_backlinks_to" do
+    test "returns a list of notes that link to the given slug" do
+      notes = Notes.with_backlinks_to("backlinks")
 
-    test "when the text parses to a note's title" do
-      assert Notes.find_note_from_link_text("I'm a bird") == Notes.get("nested.bird")
-    end
-
-    test "when no note can be found" do
-      refute Notes.find_note_from_link_text("No chance in hell")
+      assert notes == [note_from_filepath("with_neither_header_nor_h1")]
     end
   end
 


### PR DESCRIPTION
Adds the ability to generate a list of backlinks inside a note, and
to generate a list of notes that link to a specific note.

Both these lists are displayed in the side (top on narrow screens) nav
while viewing a note.

This feature removes the ability to link to a note via its title
directly. Doing so created a circular logic where to define a backlink
the attached note needed to be loaded, but to load that note it had
to search for backlinks, etc.

NB. There may be a way to allow backlinks to display titles, but they would
still have to be detected/defined by the linked path.