### PR TITLE
Can specify a title in addition to a path for a backlink.

### DIFF
--- a/lib/xettelkasten_server/backlink.ex
+++ b/lib/xettelkasten_server/backlink.ex
@@ -8,12 +8,23 @@ defmodule XettelkastenServer.Backlink do
   alias XettelkastenServer.TextHelpers
 
   def from_text(text) do
-    path = TextHelpers.text_to_path(text)
+    {path, title} =
+      case String.split(text, "|", trim: true) do
+        [path] ->
+          path = String.trim(path)
+          {path, path}
+
+        [path, title] ->
+          {String.trim(path), String.trim(title)}
+      end
+
+    slug = TextHelpers.text_to_slug(path)
+    path = TextHelpers.text_to_path(path)
 
     %__MODULE__{
-      text: text,
+      text: title,
       path: path,
-      slug: TextHelpers.text_to_slug(text),
+      slug: slug,
       missing: !File.exists?(path)
     }
   end

--- a/test/support/notes/simple_backlink.md
+++ b/test/support/notes/simple_backlink.md
@@ -1,3 +1,3 @@
 # Simple backlink
 
-[[very simple]]
+[[very simple|A Very Simple Backlink]]

--- a/test/xettelkasten_server/backlink_test.exs
+++ b/test/xettelkasten_server/backlink_test.exs
@@ -30,5 +30,15 @@ defmodule XettelkastenServer.BacklinkTest do
       assert backlink.slug == "not_a_note"
       assert backlink.missing
     end
+
+    test "works with a backlink specifying path and title" do
+      backlink = Backlink.from_text("simple|A Simple Note")
+
+      assert backlink.text == "A Simple Note"
+      assert backlink.path == Path.join(XettelkastenServer.notes_directory(), "simple.md")
+      assert backlink.slug == "simple"
+      refute backlink.missing
+
+    end
   end
 end

--- a/test/xettelkasten_server/router_test.exs
+++ b/test/xettelkasten_server/router_test.exs
@@ -116,7 +116,7 @@ defmodule XettelkastenServer.RouterTest do
       assert length(sidebar_backlink_links) == 1
 
       assert sidebar_backlink_links ==
-               [{"a", [{"class", "backlink"}, {"href", "/very_simple"}], ["Very Simple"]}]
+               [{"a", [{"class", "backlink"}, {"href", "/very_simple"}], ["A Very Simple Backlink"]}]
     end
 
     test "renders a list of incoming backlinks in the side nav" do


### PR DESCRIPTION
If a backlink is defined in markdown as two string separated by a "|",
the first will be assumed to be a parseable path to another note, and
the second will be the title printed in the rendered HTML.

If no "|" is part of the backlink's text, the whole string will be used
as both the path and the displayed HTML content
