### PR TITLE
Fix config and template settings to allow including this app as a dependency

### DIFF
--- a/lib/xettelkasten_server/application.ex
+++ b/lib/xettelkasten_server/application.ex
@@ -1,6 +1,4 @@
 defmodule XettelkastenServer.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
 
   use Application
@@ -9,18 +7,18 @@ defmodule XettelkastenServer.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      # Starts a worker by calling: XettelkastenServer.Worker.start_link(arg)
-      # {XettelkastenServer.Worker, arg}
-      {Plug.Cowboy, scheme: :http, plug: XettelkastenServer.Router, port: cowboy_port()}
+      {Plug.Cowboy,
+       scheme: :http, plug: XettelkastenServer.Router, options: [port: cowboy_port()]}
     ]
 
-    Logger.info("Starting XettelkastenServer on port #{cowboy_port()}")
+    Logger.info("Starting Xettelkasten server on port #{cowboy_port()}")
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: XettelkastenServer.Supervisor]
+
     Supervisor.start_link(children, opts)
   end
 
-  defp cowboy_port, do: Application.get_env(:xettelkasten_server, :cowboy_port)
+  defp cowboy_port do
+    Application.get_env(:xettelkasten_server, :cowboy_port, 8080)
+  end
 end

--- a/lib/xettelkasten_server/router.ex
+++ b/lib/xettelkasten_server/router.ex
@@ -3,14 +3,15 @@ defmodule XettelkastenServer.Router do
 
   alias XettelkastenServer.{Backlink, Note, Notes, TextHelpers}
 
-  @templates_dir "priv/static/templates"
+  @priv_static Path.join(Path.dirname(__ENV__.file), "../../priv/static")
+  @templates_dir Path.join(@priv_static, "templates")
 
   plug(Plug.Logger, log: :debug)
 
   plug(
     Plug.Static,
     at: "/",
-    from: "priv/static",
+    from: @priv_static,
     gzip: false,
     only: ~w(styles.css)
   )


### PR DESCRIPTION
Update `Router` template paths to be generated as absolute paths, rather than relative. This allows the paths to be correctly followed when this app is included as a dependency in another.

Also clean up the `Application` implementation.