### PR TITLE
Add step to MarkdownParser to add `language-` prefix to prism codeblock classname

### DIFF
--- a/lib/xettelkasten_server/markdown_parser.ex
+++ b/lib/xettelkasten_server/markdown_parser.ex
@@ -18,6 +18,7 @@ defmodule XettelkastenServer.MarkdownParser do
         node
         |> detect_backlinks(backlink_agent)
         |> detect_tags()
+        |> prismify()
       end)
       |> ensure_h1_tag(title)
 
@@ -102,4 +103,14 @@ defmodule XettelkastenServer.MarkdownParser do
         [{"h1", [], [[title]], %{}} | ast]
     end
   end
+
+  defp prismify({"code", attrs, content, extra}) do
+    {"class", lang} = class_attr = Enum.find(attrs, fn {key, _} -> key == "class" end)
+    new_class_attr = {"class", "language-#{lang}"}
+
+    new_attrs = List.delete(attrs, class_attr) |> List.insert_at(0, new_class_attr)
+    {"code", new_attrs, content, extra}
+  end
+
+  defp prismify(ast), do: ast
 end

--- a/test/xettelkasten_server/markdown_parser_test.exs
+++ b/test/xettelkasten_server/markdown_parser_test.exs
@@ -151,4 +151,23 @@ defmodule XettelkastenServer.MarkdownParserTest do
              ]
     end
   end
+
+  describe "complete-prism-tags" do
+    test "it prefixes the language class name with `language-`" do
+      content = """
+      ```elixir
+      defmodule Foo do
+      def bar, do: :ok
+      end
+      ```
+      """
+
+      {:ok, ast, _} = MarkdownParser.parse(content)
+
+      {"pre", _, [{"code", code_attrs, _, _}], _} = Enum.find(ast, fn {tag, _, _, _} -> tag == "pre" end)
+
+      assert {"class", "language-elixir"} in code_attrs
+
+    end
+  end
 end


### PR DESCRIPTION
Add step to MarkdownParser to add language- prefix to prism codeblock classname