### PR TITLE
Add a file watcher for the server's notes directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         - otp: 21
           elixir: "1.13.3"
     steps:
+      - name: install inotify
+        run: sudo apt-get install -y inotify-tools
+
       - uses: actions/checkout@v2.4.0
 
       - uses: erlef/setup-beam@v1
@@ -65,4 +68,5 @@ jobs:
         if: steps.mix-cache.outputs.cache-hit != 'true'
 
       - name: mix test
-        run: mix test
+        run: FILE_WATCHER_DELAY_MS=1000 mix test
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,9 @@ config :xettelkasten_server, notes_directory: "test/support/notes"
 
 config :logger, level: :error
 
+config :xettelkasten_server,
+  file_watcher_delay_ms: System.get_env("FILE_WATCHER_DELAY_MS", "100") |> String.to_integer()
+
 config :mix_test_watch,
   tasks: [
     "test",

--- a/lib/xettelkasten_server/application.ex
+++ b/lib/xettelkasten_server/application.ex
@@ -7,6 +7,7 @@ defmodule XettelkastenServer.Application do
   @impl true
   def start(_type, _args) do
     children = [
+      {XettelkastenServer.NoteWatcher, []},
       {Plug.Cowboy,
        scheme: :http, plug: XettelkastenServer.Router, options: [port: cowboy_port()]}
     ]

--- a/lib/xettelkasten_server/note.ex
+++ b/lib/xettelkasten_server/note.ex
@@ -12,7 +12,7 @@ defmodule XettelkastenServer.Note do
       {:ok, _body} ->
         %{yaml: yaml, markdown: markdown} = NoteFileReader.read(path)
 
-        tags_from_yaml = Enum.map(yaml["tags"], &"##{&1}")
+        tags_from_yaml = yaml["tags"]
         tags_from_body = extract_tags_from_markdown(markdown)
         title_from_body = extract_title_from_markdown(markdown)
 
@@ -37,7 +37,8 @@ defmodule XettelkastenServer.Note do
   end
 
   defp extract_tags_from_markdown(text) do
-    Regex.scan(~r/#[^#\s]+/, text)
+    Regex.scan(~r/#([^#\s]+)/, text)
+    |> Enum.map(fn [_, tag] -> tag end)
     |> List.flatten()
   end
 

--- a/lib/xettelkasten_server/note_watcher.ex
+++ b/lib/xettelkasten_server/note_watcher.ex
@@ -1,0 +1,80 @@
+defmodule XettelkastenServer.NoteWatcher do
+  @moduledoc """
+    GenServer that stores the current state for notes to avoid frequent calls to `Notes.all()`.
+
+    It includes a file watcher on the specified notes directory to reload notes as they change.
+  """
+  use GenServer
+  require Logger
+
+  @watcher_name XettelkastenServer.NoteWatcher.Watcher
+
+  alias XettelkastenServer.{Note, TextHelpers}
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    fs_args = [dirs: [XettelkastenServer.notes_directory()], name: @watcher_name]
+    {:ok, _} = FileSystem.start_link(fs_args)
+    FileSystem.subscribe(@watcher_name)
+
+    {:ok, %{notes: initial_notes_load()}}
+  end
+
+  def notes do
+    GenServer.call(__MODULE__, :notes)
+  end
+
+  def handle_call(:notes, _, %{notes: notes} = state) do
+    {:reply, Map.values(notes), state}
+  end
+
+  def handle_info({:file_event, _watcher_pid, {path, events}}, %{notes: notes} = state) do
+    new_notes =
+      cond do
+        is_delete?(events) -> delete_note(path, notes)
+        is_update?(events) -> update_note(path, notes)
+        true -> notes
+      end
+
+    {:noreply, %{state | notes: new_notes}}
+  end
+
+  def handle_info({:file_event, _watcher_pid, :stop}, state) do
+    {:noreply, state}
+  end
+
+  defp delete_note(path, state) do
+    Logger.info("deleting note at #{path}")
+    Map.delete(state, path)
+  end
+
+  defp update_note(path, state) do
+    Logger.info("updating note at #{path}")
+    Map.put(state, path, XettelkastenServer.Note.from_path(TextHelpers.trim_path(path)))
+  end
+
+  defp initial_notes_load do
+    XettelkastenServer.notes_directory()
+    |> Path.join("**/*.md")
+    |> Path.wildcard()
+    |> Enum.map(&Note.from_path/1)
+    |> Enum.map(fn %{path: path} = note ->
+      {
+        Path.join(Path.absname(""), path),
+        note
+      }
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp is_delete?(events) do
+    :deleted in events or :removed in events
+  end
+
+  defp is_update?(events) do
+    :modified in events or :created in events
+  end
+end

--- a/lib/xettelkasten_server/notes.ex
+++ b/lib/xettelkasten_server/notes.ex
@@ -3,27 +3,15 @@ defmodule XettelkastenServer.Notes do
     Query methods for notes
   """
 
-  alias XettelkastenServer.Note
+  alias XettelkastenServer.NoteWatcher
 
   def all do
-    XettelkastenServer.notes_directory()
-    |> Path.join("**/*.md")
-    |> Path.wildcard()
-    |> Enum.map(&Note.from_path/1)
+    NoteWatcher.notes()
   end
 
   def all(tag: tag) when is_bitstring(tag) do
-    {paths_from_md_tag, _} =
-      System.cmd("grep", ["-lr", "-e", "##{tag}\\b", XettelkastenServer.notes_directory()])
-
-    {paths_from_yaml_tag, _} =
-      System.cmd("grep", ["-lr", "-e", "- #{tag}\\b", XettelkastenServer.notes_directory()])
-
-    paths = paths_from_md_tag <> "\n" <> paths_from_yaml_tag
-
-    paths
-    |> String.split("\n", trim: true)
-    |> Enum.map(&Note.from_path/1)
+    all()
+    |> Enum.filter(&(tag in &1.tags))
   end
 
   def get(slug) do

--- a/lib/xettelkasten_server/text_helpers.ex
+++ b/lib/xettelkasten_server/text_helpers.ex
@@ -62,4 +62,10 @@ defmodule XettelkastenServer.TextHelpers do
       |> String.replace(" ", "_")
     end)
   end
+
+  def trim_path(path) do
+    path
+    |> String.replace(Path.absname(""), "")
+    |> String.trim_leading("/")
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule XettelkastenServer.MixProject do
     [
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:earmark, "~> 1.4.24"},
+      {:file_system, "~> 0.2"},
       {:floki, "~> 0.32.0", only: [:dev, :test]},
       {:plug_cowboy, "~> 2.0"},
       {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},

--- a/test/xettelkasten_server/note_test.exs
+++ b/test/xettelkasten_server/note_test.exs
@@ -32,7 +32,7 @@ defmodule XettelkastenServer.NoteTest do
                path: ^path,
                slug: "with_header",
                title: "My Cool Note",
-               tags: ~w(#awesome #more_tags #prettycool #sweet #tags),
+               tags: ~w(awesome more_tags prettycool sweet tags),
                backlinks: [
                  %Backlink{
                    missing: true,

--- a/test/xettelkasten_server/note_watcher_test.exs
+++ b/test/xettelkasten_server/note_watcher_test.exs
@@ -1,0 +1,61 @@
+defmodule XettelkastenServer.NoteWatcherTest do
+  use ExUnit.Case
+
+  @delay Application.compile_env(:xettelkasten_server, :file_watcher_delay_ms)
+
+  setup do
+    on_exit(fn -> File.rm("test/support/notes/my_test_note.md") end)
+  end
+
+  test "updates the state" do
+    base_path =
+      Path.join(
+        XettelkastenServer.notes_directory(),
+        "my_test_note.md"
+      )
+
+    path =
+      Path.join(
+        Path.absname(""),
+        base_path
+      )
+
+    refute XettelkastenServer.Notes.get("my_test_note")
+
+    :ok = File.write!(path, "# hello!", [:write])
+
+    :timer.sleep(@delay)
+
+    %XettelkastenServer.Note{tags: tags} = XettelkastenServer.Notes.get("my_test_note")
+
+    assert tags == []
+
+    :timer.sleep(@delay)
+
+    File.write!(path, """
+    ---
+    tags:
+    - foo
+    - bar
+    ---
+    hello
+    """)
+
+    :timer.sleep(@delay)
+
+    %XettelkastenServer.Note{tags: tags} = XettelkastenServer.Notes.get("my_test_note")
+
+    assert tags == ~w(bar foo)
+
+    :timer.sleep(@delay)
+
+    :ok = File.rm(path)
+
+    :timer.sleep(@delay)
+
+    refute XettelkastenServer.Notes.get("my_test_note")
+  end
+
+  def my_test_note_path do
+  end
+end

--- a/test/xettelkasten_server/router_test.exs
+++ b/test/xettelkasten_server/router_test.exs
@@ -98,7 +98,7 @@ defmodule XettelkastenServer.RouterTest do
       assert length(sidebar_tag_links) == 5
 
       assert Enum.map(sidebar_tag_links, fn {_, _, [tag]} -> tag end) ==
-               ~w(#awesome #more_tags #prettycool #sweet #tags)
+               ~w(awesome more_tags prettycool sweet tags)
     end
 
     test "renders a list of outgoing backlinks in the side nav" do
@@ -116,7 +116,10 @@ defmodule XettelkastenServer.RouterTest do
       assert length(sidebar_backlink_links) == 1
 
       assert sidebar_backlink_links ==
-               [{"a", [{"class", "backlink"}, {"href", "/very_simple"}], ["A Very Simple Backlink"]}]
+               [
+                 {"a", [{"class", "backlink"}, {"href", "/very_simple"}],
+                  ["A Very Simple Backlink"]}
+               ]
     end
 
     test "renders a list of incoming backlinks in the side nav" do


### PR DESCRIPTION
- On startup, it loads all notes and stores them in state
- Watches for file changes in the notes directory and updates the GenServer state accordingly

## Other changes

Stores tags in note structs without the leading `#` as that is a display-level syntax, not data