### PR TITLE
Reload notes with backlinks to a updated note

### DIFF
--- a/lib/xettelkasten_server/text_helpers.ex
+++ b/lib/xettelkasten_server/text_helpers.ex
@@ -8,7 +8,7 @@ defmodule XettelkastenServer.TextHelpers do
   def titleize(s) do
     s
     |> String.split("/", trim: true)
-    |> Enum.map_join(" /", fn nest ->
+    |> Enum.map_join(" / ", fn nest ->
       nest
       |> String.split(" ", trim: true)
       |> Enum.map_join(" ", &String.capitalize/1)


### PR DESCRIPTION
When a note is added or removed, there is the possibility that it will effect backlinks in other notes.

This adds a step in the NoteWatcher that, on a note change, checks for any notes that link to it
and reloads them to ensure their backlinks are up to date.
