### PR TITLE
Updates to the NoteWatcher GenServer

### DIFF
--- a/lib/xettelkasten_server/application.ex
+++ b/lib/xettelkasten_server/application.ex
@@ -6,6 +6,8 @@ defmodule XettelkastenServer.Application do
 
   @impl true
   def start(_type, _args) do
+    Application.ensure_started(:file_system)
+
     children = [
       {XettelkastenServer.NoteWatcher, []},
       {Plug.Cowboy,

--- a/test/xettelkasten_server/note_watcher_test.exs
+++ b/test/xettelkasten_server/note_watcher_test.exs
@@ -10,6 +10,7 @@ defmodule XettelkastenServer.NoteWatcherTest do
       File.rm("test/support/notes/my_test_note.md")
       File.rm("test/support/notes/linking_note.md")
       File.rm("test/support/notes/linked_note.md")
+      File.rmdir("test/support/notes/test_nest")
     end)
   end
 
@@ -99,5 +100,17 @@ defmodule XettelkastenServer.NoteWatcherTest do
              slug: "linked_note",
              missing: false
            } in backlinks
+  end
+
+  test "doesn't crash if a new directory is created" do
+    pid = Process.whereis(XettelkastenServer.NoteWatcher)
+    fs_pid = Process.whereis(XettelkastenServer.NoteWatcher.Watcher)
+    path = Path.join(XettelkastenServer.notes_directory(), "test_nest")
+    File.mkdir!(path)
+
+    :timer.sleep(@delay)
+
+    assert Process.alive?(fs_pid)
+    assert Process.alive?(pid)
   end
 end


### PR DESCRIPTION
- Ensure file_system app can start, and error if the monitor doesn't boot
- Ensure watcher process doesn't crash when directory is created
  - Only reload on changes to markdown files
- Refactor event hooks
